### PR TITLE
Fixed include paths and typos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,8 +122,8 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 #add_subdirectory (math)
 set(WITH_VOLUME true)
 set(WITH_VOLUME_WIDGETS true)
-#add_subdirectory(../teamspeak-plugin-qt-common common_out)
-include(../teamspeak-plugin-qt-common/CMakeLists.txt)
+#add_subdirectory(./deps/teamspeak-plugin-qt-common common_out)
+include(./deps/teamspeak-plugin-qt-common/CMakeLists.txt)
 
 add_library(CrossTalk SHARED
     ${PLUGIN_SRC} ${TS_QT_CORE} ${TS_QT_VOLUME} ${QT_WEBSOCKET} ${POSITIONAL_AUDIO})

--- a/deps/QtWebsocket/ServerThreaded/ServerThreaded.h
+++ b/deps/QtWebsocket/ServerThreaded/ServerThreaded.h
@@ -23,9 +23,9 @@ along with QtWebsocket.  If not, see <http://www.gnu.org/licenses/>.
 #include <QtCore/QtCore>
 #include <QtNetwork/QtNetwork>
 
-#include "QtWebSocket/QWsServer.h"
-#include "QtWebSocket/QWsSocket.h"
-#include "QtWebSocket/ServerThreaded/SocketThread.h"
+#include "QtWebsocket/QWsServer.h"
+#include "QtWebsocket/QWsSocket.h"
+#include "QtWebsocket/ServerThreaded/SocketThread.h"
 
 class ServerThreaded : public QObject
 {

--- a/deps/QtWebsocket/ServerThreaded/SocketThread.h
+++ b/deps/QtWebsocket/ServerThreaded/SocketThread.h
@@ -22,7 +22,7 @@ along with QtWebsocket.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <QtCore/QThread>
 
-#include "QtWebSocket/QWsSocket.h"
+#include "QtWebsocket/QWsSocket.h"
 
 class SocketThread : public QThread
 {

--- a/src/banner.h
+++ b/src/banner.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QtWidgetS/QLabel>
+#include <QtWidgets/QLabel>
 #include <QtCore/QObject>
 #include <QtGui/QMouseEvent>
 

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -111,7 +111,7 @@ void ts3plugin_configure(void* handle, void* qParentWidget) { plugin->configure(
  * can be omitted.
  * Note the passed pluginID parameter is no longer valid after calling this function, so you must copy it and store it in the plugin.
  */
-void ts3plugin_registerPluginID(const char* id) { plugin.swap(std::make_unique<Plugin>(id)); }
+void ts3plugin_registerPluginID(const char* id) { plugin = std::make_unique<Plugin>(id); }
 
 /* Plugin command keyword. Return NULL or "" if not used. */
 const char* ts3plugin_commandKeyword() { return "ct"; }

--- a/src/plugin_qt.h
+++ b/src/plugin_qt.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "core/plugin_base.h"
-#include "QtWebSocket/ServerThreaded/ServerThreaded.h"
+#include "QtWebsocket/ServerThreaded/ServerThreaded.h"
 
 class ChannelMuter;
 class PositionSpread;

--- a/src/positional_audio/settings_positionalaudio.cpp
+++ b/src/positional_audio/settings_positionalaudio.cpp
@@ -116,19 +116,7 @@ void SettingsPositionalAudio::onContextMenuEvent(uint64 serverConnectionHandlerI
 
     if (type == PLUGIN_MENU_TYPE_GLOBAL)
     {
-        if (menuItemID == m_ContextMenuGW2Map)
-        {
-            QUrl gwUrl("http://thorwe.github.io/CrossTalk/misc/site/gw2/html/gw2maps-leaflet.html");
-
-            auto plugin = qobject_cast<Plugin*>(parent());
-            auto& websocket_server = plugin->websocket_server();
-            const auto kPort = websocket_server.getPort();
-            gwUrl.setQuery(QString("websocket_port=%1").arg(kPort));
-
-            //port = PluginQt::instance()->getServerPort(); //todo add query
-            QDesktopServices::openUrl(gwUrl);
-        }
-        else if (menuItemID == m_ContextMenuUi)
+        if (menuItemID == m_ContextMenuUi)
         {
             if (config)
                 config.data()->activateWindow();
@@ -232,6 +220,20 @@ void SettingsPositionalAudio::onContextMenuEvent(uint64 serverConnectionHandlerI
                 config = p_config;
             }
         }
+#ifdef Q_OS_WIN
+        else if (menuItemID == m_ContextMenuGW2Map)
+        {
+            QUrl gwUrl("http://thorwe.github.io/CrossTalk/misc/site/gw2/html/gw2maps-leaflet.html");
+
+            auto plugin = qobject_cast<Plugin*>(parent());
+            auto& websocket_server = plugin->websocket_server();
+            const auto kPort = websocket_server.getPort();
+            gwUrl.setQuery(QString("websocket_port=%1").arg(kPort));
+
+            //port = PluginQt::instance()->getServerPort(); //todo add query
+            QDesktopServices::openUrl(gwUrl);
+        }
+#endif
     }
 }
 


### PR DESCRIPTION
Building CrossTalk fails due to an invalid include path for teamspeak-plugin-qt-common in CMakeLists.txt. Also, there were a few case-sensitive typos.